### PR TITLE
Optimize tile redraw logic

### DIFF
--- a/RabiRibi_Editor/MainForm.cs
+++ b/RabiRibi_Editor/MainForm.cs
@@ -263,7 +263,7 @@ namespace RabiRibi_Editor
       }
       
       // Initialize stuff
-      command_stack = new CommandStack(level);
+      command_stack = new CommandStack(level, tileView1);
       
       metatile_list = new List<Metatile>();
       
@@ -844,8 +844,6 @@ namespace RabiRibi_Editor
       }
       
       CheckUndoEnabled();
-      
-      tileView1.Invalidate();
     }
     
     void Process_Right_Click(int tile_x, int tile_y)
@@ -1086,14 +1084,12 @@ namespace RabiRibi_Editor
     {
       command_stack.Undo();
       CheckUndoEnabled();
-      tileView1.Invalidate();
     }
     
     void RedoToolStripMenuItemClick(object sender, EventArgs e)
     {
       command_stack.Redo();
       CheckUndoEnabled();
-      tileView1.Invalidate();
     }
     
     void CheckUndoEnabled()


### PR DESCRIPTION
Only redraw parts of the tile view as needed.  This includes only
redrawing updated areas of the map when making modifications, as well as
respecting the clip rectangle when redrawing after part of the tile view
has been invalidated.