### PR TITLE
Adding confirmation when discarding changes.

### DIFF
--- a/RabiRibi_Editor/CommandStack.cs
+++ b/RabiRibi_Editor/CommandStack.cs
@@ -138,6 +138,11 @@ namespace RabiRibi_Editor
     BoundedStack undo_stack;
     BoundedStack redo_stack;
     
+    // This tracks the number of changes.  Any action or Redo counts +1, any
+    // Undo counts -1.  If this value is non-zero, then changes have been made
+    // to the currently-loaded level data.
+    int number_of_changes = 0;
+    
     public CommandStack(LevelData l, TileView t)
     {
       level = l;
@@ -171,6 +176,8 @@ namespace RabiRibi_Editor
       {
         RunCommandInternal(command[i]);
       }
+      
+      number_of_changes++;
     }
     
     /// <summary>
@@ -271,6 +278,7 @@ namespace RabiRibi_Editor
         {
           RunCommandInternal(cmd[i]);
         }
+        number_of_changes--;
       }
     }
     
@@ -287,6 +295,7 @@ namespace RabiRibi_Editor
         {
           RunCommandInternal(cmd[i]);
         }
+        number_of_changes++;
       }
     }
     
@@ -308,6 +317,21 @@ namespace RabiRibi_Editor
     {
       undo_stack.Clear();
       redo_stack.Clear();
+      number_of_changes = 0;
+    }
+    
+    internal bool ChangesMade()
+    {
+      return number_of_changes != 0;
+    }
+    
+    /// <summary>
+    /// Resets the change count tracked by the command stack.  This should be
+    /// used when the currently loaded data is saved.
+    /// </summary>
+    internal void ResetChangeCount()
+    {
+      number_of_changes = 0;
     }
   }
 }

--- a/RabiRibi_Editor/MainForm.Designer.cs
+++ b/RabiRibi_Editor/MainForm.Designer.cs
@@ -38,6 +38,7 @@ namespace RabiRibi_Editor
     {
       this.menuStrip1 = new System.Windows.Forms.MenuStrip();
       this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.newLevelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
@@ -94,7 +95,6 @@ namespace RabiRibi_Editor
       this.tools_panel = new System.Windows.Forms.Panel();
       this.splitContainer1 = new System.Windows.Forms.SplitContainer();
       this.metatile_layer_label = new System.Windows.Forms.Label();
-      this.newLevelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.menuStrip1.SuspendLayout();
       this.tabControl1.SuspendLayout();
       this.tabPage1.SuspendLayout();
@@ -136,6 +136,14 @@ namespace RabiRibi_Editor
       this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
       this.fileToolStripMenuItem.Size = new System.Drawing.Size(35, 20);
       this.fileToolStripMenuItem.Text = "File";
+      // 
+      // newLevelToolStripMenuItem
+      // 
+      this.newLevelToolStripMenuItem.Name = "newLevelToolStripMenuItem";
+      this.newLevelToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
+      this.newLevelToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
+      this.newLevelToolStripMenuItem.Text = "New Level";
+      this.newLevelToolStripMenuItem.Click += new System.EventHandler(this.NewLevelToolStripMenuItemClick);
       // 
       // openToolStripMenuItem
       // 
@@ -938,14 +946,6 @@ namespace RabiRibi_Editor
       this.metatile_layer_label.Size = new System.Drawing.Size(100, 23);
       this.metatile_layer_label.TabIndex = 0;
       // 
-      // newLevelToolStripMenuItem
-      // 
-      this.newLevelToolStripMenuItem.Name = "newLevelToolStripMenuItem";
-      this.newLevelToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-      this.newLevelToolStripMenuItem.Size = new System.Drawing.Size(168, 22);
-      this.newLevelToolStripMenuItem.Text = "New Level";
-      this.newLevelToolStripMenuItem.Click += new System.EventHandler(this.NewLevelToolStripMenuItemClick);
-      // 
       // MainForm
       // 
       this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -957,6 +957,7 @@ namespace RabiRibi_Editor
       this.MinimumSize = new System.Drawing.Size(650, 600);
       this.Name = "MainForm";
       this.Text = "RabiRibi_Editor";
+      this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainFormFormClosing);
       this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.MainFormFormClosed);
       this.menuStrip1.ResumeLayout(false);
       this.menuStrip1.PerformLayout();


### PR DESCRIPTION
Adding a prompt to the user under the following circumstances to save or
discard changes to the current data, if any changes are present:
1) The user selects to start a new level
2) The user selects to open a level file
3) The user goes to close the editor.

Implements updates for issue #33 